### PR TITLE
MarkableInputStream now has the ability to automaticlly grow the unde…

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -122,7 +122,7 @@ class BitmapHunter implements Runnable {
     MarkableInputStream markStream = new MarkableInputStream(stream);
     stream = markStream;
 
-    long mark = markStream.savePosition(65536); // TODO fix this crap.
+    long mark = markStream.savePosition(2048); // TODO fix this crap.
 
     final BitmapFactory.Options options = RequestHandler.createBitmapOptions(request);
     final boolean calculateSize = RequestHandler.requiresInSampleSize(options);
@@ -143,7 +143,9 @@ class BitmapHunter implements Runnable {
       return BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
     } else {
       if (calculateSize) {
+        markStream.startGrowingBuffer();
         BitmapFactory.decodeStream(stream, null, options);
+        markStream.stopGrowingBuffer();
         RequestHandler.calculateInSampleSize(request.targetWidth, request.targetHeight, options,
             request);
 


### PR DESCRIPTION
…rlying input stream's buffer.

BitmapHunter uses this ability to ensure that images which require reading more than 65536 bytes
  to determine bounds succeed in loading.
